### PR TITLE
Update regular expression to match multiple proxies

### DIFF
--- a/proxy-login-automator.js
+++ b/proxy-login-automator.js
@@ -167,7 +167,7 @@ function createPacServer(local_host, local_port, remote_host, remote_port, buf_p
             }).on('end', function () {
                 var s = Buffer.concat(buf_ary).toString();
                 buf_ary = [];
-                s = s.replace(/(['"])PROXY\s+([^'":\s]+)(:\d+)?\1/g, function (matched_all, matched_quot, matched_remote_host, matched_comma_remote_port) {
+                s = s.replace(/PROXY\s+([^'":\s]+)(:\d+)?/g, function (matched_all, matched_remote_host, matched_comma_remote_port) {
                     var _remote_port = matched_comma_remote_port && Number(matched_comma_remote_port.slice(1)) || 80;
                     var remoteAddr = matched_remote_host + ':' + _remote_port;
                     var _local_port = proxyAddrMap[remoteAddr];
@@ -176,7 +176,7 @@ function createPacServer(local_host, local_port, remote_host, remote_port, buf_p
                         proxyAddrMap[remoteAddr] = _local_port;
                         createPortForwarder(local_host, _local_port, matched_remote_host, _remote_port, buf_proxy_basic_auth);
                     }
-                    return matched_quot + 'PROXY localhost:' + _local_port + matched_quot;
+                    return 'PROXY localhost:' + _local_port;
                 });
                 //console.log('return patched pac');
                 res.end(s);


### PR DESCRIPTION
Hi. Thank you for providing this great tool. I allowed myself to update one line of the code, because our company proxy pac file uses directives with multiple PROXY directives in one line. So I updated the regular expression to be able to match multiple PROXY directives like "PROXY foo.bar:8080; PROXY bar.foo:8080;".